### PR TITLE
Added GML support

### DIFF
--- a/base/gdal2.4/Dockerfile
+++ b/base/gdal2.4/Dockerfile
@@ -117,7 +117,6 @@ RUN cd /tmp/gdal \
       --without-bsb \
       --without-cfitsio \
       --without-ecw \
-      --without-expat \
       --without-fme \
       --without-freexl \
       --without-gif \
@@ -149,7 +148,6 @@ RUN cd /tmp/gdal \
       --without-python \
       --without-qhull \
       --without-sde \
-      --without-xerces \
       --without-xml2
 
 RUN cd /tmp/gdal \

--- a/base/gdal3.0/Dockerfile
+++ b/base/gdal3.0/Dockerfile
@@ -115,7 +115,6 @@ RUN cd /tmp/gdal \
       --without-bsb \
       --without-cfitsio \
       --without-ecw \
-      --without-expat \
       --without-fme \
       --without-freexl \
       --without-gif \
@@ -147,7 +146,6 @@ RUN cd /tmp/gdal \
       --without-python \
       --without-qhull \
       --without-sde \
-      --without-xerces \
       --without-xml2
 
 RUN cd /tmp/gdal \

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -7,6 +7,7 @@ if [[ ! "$(gdal-config --formats | grep 'mbtiles')" ]]; then echo "NOK" && exit 
 if [[ ! "$(gdal-config --formats | grep 'webp')" ]]; then echo "NOK" && exit 1; fi
 if [[ ! "$(gdal-config --formats | grep 'jpeg')" ]]; then echo "NOK" && exit 1; fi
 if [[ ! "$(gdal-config --formats | grep 'png')" ]]; then echo "NOK" && exit 1; fi
+if [[ ! "$(ogrinfo --formats | grep 'GML')" ]]; then echo "NOK" && exit 1; fi
 
 echo "OK"
 exit 0


### PR DESCRIPTION
Fixes #11 

When trying to use GML drivers it resulted in errors. Using gdal in python, `ogr.Open` returned `None`. When trying to read files using `ogrinfo`, it resulted in this:

```bash
$ ogrinfo out.gml 
ERROR 1: Unable to create Xerces C++ or Expat based GML reader, Xerces or Expat support not configured into GDAL/OGR.
ERROR 1: File out.gml appears to be GML but the GML reader can't
be instantiated, likely because Xerces or Expat support was
not configured in.
FAILURE:
Unable to open datasource `out.gml' with the following drivers.
  -> PDS4
  -> JP2OpenJPEG
  -> PDF
  -> MBTiles
  -> EEDA
  -> ESRI Shapefile
...
```

The addition of these libraries did not result in big changes in layer size when generating it. It stayed in the range of ~34Mb.